### PR TITLE
### Fix: Ensure empty line before CSS rule in `@keyframes fade-in`

### DIFF
--- a/style.css
+++ b/style.css
@@ -360,6 +360,7 @@ p {
     opacity: 0; /* Starts fully transparent */
     transform: translateY(20px); /* Moves element 20px downward */
   }
+
   to {
     opacity: 1; /* Becomes fully visible */
     transform: translateY(0); /* Moves to original position */


### PR DESCRIPTION
#### Changes:
- Added an empty line before the `to {}` rule inside the `@keyframes fade-in` animation.
- Resolves **Stylelint error:** `Expected empty line before rule (rule-empty-line-before)`.
- Improves code readability and aligns with CSS formatting best practices.

#### Updated Code:
```css
@keyframes fade-in {
  from {
    opacity: 0; /* Starts fully transparent */
    transform: translateY(20px); /* Moves element 20px downward */
  }

  to {
    opacity: 1; /* Becomes fully visible */
    transform: translateY(0); /* Moves to original position */
  }
}